### PR TITLE
Fix(AppUrl): Construct valid url for root urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - breaking: upgraded `ft_sys` and `ft_sys_common` to 0.2.0 (`ft-sdk` re-exports
   `ft_sys_common::Email` etc)
 - added `ft_sdk::{WasmPackage, MainPackage}` "extractors"
+- fix: handle `/` url in `ft_sdk::AppUrl`
 
 ### ft-sys: 0.2.0
 

--- a/ft-sdk/src/from_request/app_url.rs
+++ b/ft-sdk/src/from_request/app_url.rs
@@ -122,5 +122,10 @@ pub(crate) fn from_request(
         ft_sdk::println!("app-url not found for {key}");
     }
 
-    Ok(v.map(|v| format!("/{}/", v.trim_matches('/'))))
+    Ok(v.map(|v| {
+        if v == "/" {
+            return "/".to_string();
+        }
+        format!("/{}/", v.trim_matches('/'))
+    }))
 }


### PR DESCRIPTION
When `v` is "/". The AppUrl becomes "//" which is wrong. A guard is added to protect against this case.